### PR TITLE
Fix pbis open install on redhat for enterprise rpm obsolete issue

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -159,6 +159,14 @@ class pbis (
     subscribe => Exec['join_domain']
   }
 
+  $cron_interval = fqdn_rand(23)
+  cron { 'update_DNS':
+    command => "/opt/pbis/bin/update-dns",
+    user    => 'root',
+    hour    => $cron_interval,
+    minute  => 0,
+  }
+
   # Configure PBIS
 
   $pbis_conf = '/etc/pbis/pbis.conf'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,6 +29,7 @@ class pbis::params {
   $skeleton_dirs         = '/etc/skel'
   $user_domain_prefix    = undef
   $license_key           = undef
+  $dns_ipaddress         = undef
 
   if !( $::architecture in ['amd64', 'x86_64', 'i386'] ) {
     fail("Unsupported architecture: ${::architecture}.")


### PR DESCRIPTION
On Redhat distros yum picks up pbis-enterprise rpms as obsoleting pbis-open.
Yum then installs pbis-enterprise, despite specifying pbis-open.
This change fixes it to ignore pbis-enterprise if pbis-open is requested.
